### PR TITLE
Consider dependencies for statement ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,26 @@
 ## tf-state-import
 
-A tool for importing resources from a given Terraform state file.
+A tool for importing resources from a given Terraform state file. Outputs a list of `terraform state rm`
+and `terraform state import` commands to refresh a state file. Helpful when transitioning between
+incompatible versions of a provider.
+
+Resource dependencies are considered when compiling the `rm` and `import` statements. Resources
+are removed from most dependent to least dependant resource, and imported in the opposite order.
 
 ### Usage
 
 ```
-$ go run . --tfstate=/path/to/statefile.tfstate --out=/path/to/script/import.sh
+$ go install .
 
-$ /path/to/script/import.sh
-terraform import resource id
+# Run with no flags to look in the current directory for terraform.tfstate
+# and output the commands to stdout.
+$ tf-state-import
+terraform state rm resource_foo.name
+terraform state rm resource_bar.name
 ...
+terraform state import resource_bar.name
+terraform state import resource_foo.name
+
+# Optionally pass the location of a statefile and an output script file.
+$ tf-state-import --tfstate=/path/to/statefile.tfstate --out=/path/to/script/import.sh
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/cmdpdx/tf-state-import
 
 go 1.21.1
+
+require (
+	github.com/google/go-cmp v0.5.8
+	golang.org/x/exp v0.0.0-20240112132812-db7319d0e0e3
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/exp v0.0.0-20240112132812-db7319d0e0e3 h1:hNQpMuAJe5CtcUqCXaWga3FHu+kQvCqcsoVaQgSV60o=
+golang.org/x/exp v0.0.0-20240112132812-db7319d0e0e3/go.mod h1:idGWGoKP1toJGkd5/ig9ZLuPcZBC3ewk7SzmH0uou08=

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"testing"
+)
+
+func Test_resourceOrdering_order(t *testing.T) {
+	tests := []struct {
+		name string
+		ro   resourceOrdering
+		want []*resourceTuple
+	}{{
+		name: "empty",
+		ro:   resourceOrdering{},
+		want: []*resourceTuple{},
+	}, {
+		name: "no dependencies",
+		ro: resourceOrdering{
+			m: map[string]resourceTuple{
+				"foo": {Name: "foo"},
+				"bar": {Name: "bar"},
+				"baz": {Name: "baz"},
+			},
+		},
+		want: []*resourceTuple{
+			{Name: "bar"},
+			{Name: "baz"},
+			{Name: "foo"},
+		},
+	}, {
+		name: "one dependency",
+		ro: resourceOrdering{
+			m: map[string]resourceTuple{
+				"t.foo": {
+					Type: "t",
+					Name: "foo",
+				},
+				"t.bar": {
+					Type:         "t",
+					Name:         "bar",
+					Dependencies: []string{"t.foo"},
+				},
+				"t.baz": {
+					Type: "t",
+					Name: "baz",
+				},
+			},
+		},
+		want: []*resourceTuple{
+			{
+				Type: "t",
+				Name: "foo",
+			}, {
+				Type:         "t",
+				Name:         "bar",
+				Dependencies: []string{"t.foo"},
+			}, {
+				Type: "t",
+				Name: "baz",
+			},
+		},
+	}, {
+		name: "multiple dependencies on one resource",
+		ro: resourceOrdering{
+			m: map[string]resourceTuple{
+				"t.foo": {
+					Type: "t",
+					Name: "foo",
+				},
+				"t.bar": {
+					Type:         "t",
+					Name:         "bar",
+					Dependencies: []string{"t.foo", "t.baz"},
+				},
+				"t.baz": {
+					Type: "t",
+					Name: "baz",
+				},
+			},
+		},
+		want: []*resourceTuple{
+			{
+				Type: "t",
+				Name: "foo",
+			}, {
+				Type: "t",
+				Name: "baz",
+			}, {
+				Type:         "t",
+				Name:         "bar",
+				Dependencies: []string{"t.foo", "t.baz"},
+			},
+		},
+	}, {
+		name: "dependencies on multiple resources",
+		ro: resourceOrdering{
+			m: map[string]resourceTuple{
+				"t.foo": {
+					Type:         "t",
+					Name:         "foo",
+					Dependencies: []string{"t.baz"},
+				},
+				"t.bar": {
+					Type:         "t",
+					Name:         "bar",
+					Dependencies: []string{"t.foo"},
+				},
+				"t.baz": {
+					Type: "t",
+					Name: "baz",
+				},
+			},
+		},
+		want: []*resourceTuple{
+			{
+				Type: "t",
+				Name: "baz",
+			}, {
+				Type:         "t",
+				Name:         "foo",
+				Dependencies: []string{"t.baz"},
+			}, {
+				Type:         "t",
+				Name:         "bar",
+				Dependencies: []string{"t.foo"},
+			},
+		},
+	}, {
+		name: "dependencies on multiple resources w/ duplicate names",
+		ro: resourceOrdering{
+			m: map[string]resourceTuple{
+				"t.foo": {
+					Type:         "t",
+					Name:         "foo",
+					Dependencies: []string{"t.baz"},
+				},
+				"t.bar": {
+					Type:         "t",
+					Name:         "bar",
+					Dependencies: []string{"t.foo"},
+				},
+				"t.baz": {
+					Type: "t",
+					Name: "baz",
+				},
+			},
+		},
+		want: []*resourceTuple{
+			{
+				Type: "t",
+				Name: "baz",
+			}, {
+				Type:         "t",
+				Name:         "foo",
+				Dependencies: []string{"t.baz"},
+			},
+			{
+				Type:         "t",
+				Name:         "bar",
+				Dependencies: []string{"t.foo"},
+			},
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.ro.order()
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Error("order() return mismatch (-want, +got):", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Use a depth first search algorithm to order resources by dependencies. `rm` statements are output in reverse order, `import` statements in least- to most-dependent order.

Also, allow flags to be omitted. Default output is stdout, default tfstate file location is `./terraform.tfstate`