### PR TITLE
Resource address and ID fixes

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,47 +14,27 @@ import (
 
 func main() {
 	tfstate := flag.String("tfstate", "terraform.tfstate", "tfstate file to create import statements from. If empty, looks in the current directory for 'terraform.tfstate'")
-	outFile := flag.String("out", "", "Name of the output file to write results to. If empty, prints to stdout.")
 	includeRemove := flag.Bool("include-remove", true, "Include `terraform rm` statements to alter state in place.")
 	provider := flag.String("provider", "", "Filter resources by the given provider string, including partial matches. If empty, all resources will be included.")
 	format := flag.String("format", "command", "How to structure the output, one of 'command' or 'block'. 'block' implies include-remove=false")
 	flag.Parse()
-
-	rm, err := getResources(*tfstate, *provider)
-	if err != nil {
-		log.Fatal(err)
-	}
 
 	if *format == "block" && *includeRemove {
 		log.Println("format=block implies includeRemove=false...")
 		*includeRemove = false
 	}
 
-	ordered := rm.Order()
-
-	// Create the output file, if needed. Or pass stdout.
-	var out io.Writer
-	switch {
-	case *outFile != "":
-		if !strings.HasSuffix(*outFile, ".sh") {
-			*outFile += ".sh"
-		}
-		f, err := os.Create(*outFile)
-		if err != nil {
-			log.Fatalf("failed to create script file %s: %s", *outFile, err)
-		}
-		out = f
-	default:
-		out = os.Stdout
-	}
-
-	err = output(out, ordered, *includeRemove, *format)
+	st, err := state.ParseStateFile(*tfstate)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	if *outFile != "" {
-		fmt.Fprintf(os.Stderr, "Results written to: %s\n", *outFile)
+	rm := resources.FromState(st, *provider)
+	ordered := rm.Order()
+
+	err = output(os.Stdout, ordered, *includeRemove, *format)
+	if err != nil {
+		log.Fatal(err)
 	}
 }
 
@@ -73,7 +53,7 @@ func output(out io.Writer, resources []*resources.Tuple, includeRemove bool, for
 
 	imports := make([]string, len(resources))
 	for i, r := range resources {
-		imports[i] = generateImport(r.Address(), r.ID, format)
+		imports[i] = generateImport(r.Address(), r.ImportableID(), format)
 	}
 	_, err := out.Write([]byte(strings.Join(imports, "\n") + "\n"))
 	return err
@@ -91,44 +71,4 @@ func generateImport(address, id, format string) string {
 	default:
 		return fmt.Sprintf("terraform import '%s' %s", address, id)
 	}
-}
-
-// getResources returns a map of resource name to ResourceTuple from the given file.
-func getResources(filename, provider string) (resources.ResourceMap, error) {
-	state, err := state.ParseStateFile(filename)
-	if err != nil {
-		return nil, err
-	}
-
-	rm := make(map[string]resources.Tuple, len(state.Resources))
-	for _, r := range state.Resources {
-		if r.Mode == "data" {
-			continue
-		}
-		if provider != "" && !strings.Contains(r.Provider, provider) {
-			continue
-		}
-		for _, inst := range r.Instances {
-			rawID, ok := inst.Attributes["id"]
-			if !ok {
-				// Resource doesn't have ID attribute
-				continue
-			}
-			id, ok := rawID.(string)
-			if !ok {
-				// Resource ID wasn't a string
-				continue
-			}
-			t := resources.Tuple{
-				Type:         r.Type,
-				Name:         r.Name,
-				ID:           id,
-				IndexKey:     inst.IndexKey,
-				Dependencies: inst.Dependencies,
-			}
-			rm[t.Address()] = t
-		}
-	}
-
-	return rm, nil
 }

--- a/pkg/resources/resources_test.go
+++ b/pkg/resources/resources_test.go
@@ -4,7 +4,83 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
+	"github.com/cmdpdx/tf-state-import/pkg/state"
 )
+
+func TestTupleAddress(t *testing.T) {
+	tests := []struct {
+		name string
+		t    Tuple
+		want string
+	}{{
+		name: "type and name",
+		t: Tuple{
+			Type: "type",
+			Name: "name",
+		},
+		want: "type.name",
+	}, {
+		name: "type, name, and int index",
+		t: Tuple{
+			Type:     "type",
+			Name:     "name",
+			IndexKey: 1,
+		},
+		want: "type.name[1]",
+	}, {
+		name: "type, name, and float64 index",
+		t: Tuple{
+			Type:     "type",
+			Name:     "name",
+			IndexKey: float64(1),
+		},
+		want: "type.name[1]",
+	}, {
+		name: "type, name, and string index",
+		t: Tuple{
+			Type:     "type",
+			Name:     "name",
+			IndexKey: "key",
+		},
+		want: "type.name[\"key\"]",
+	}, {
+		name: "module, type, and name",
+		t: Tuple{
+			Module: "module",
+			Type:   "type",
+			Name:   "name",
+		},
+		want: "module.type.name",
+	}, {
+		name: "module, type, name, and int index",
+		t: Tuple{
+			Module:   "module",
+			Type:     "type",
+			Name:     "name",
+			IndexKey: 1,
+		},
+		want: "module.type.name[1]",
+	}, {
+		name: "module, type, name, and string index",
+		t: Tuple{
+			Module:   "module",
+			Type:     "type",
+			Name:     "name",
+			IndexKey: "key",
+		},
+		want: "module.type.name[\"key\"]",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.t.Address()
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("Address() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
 
 func Test_resourceOrdering_order(t *testing.T) {
 	tests := []struct {
@@ -169,6 +245,122 @@ func Test_resourceOrdering_order(t *testing.T) {
 			got := test.ro.order()
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Error("order() return mismatch (-want, +got):", diff)
+			}
+		})
+	}
+}
+
+func TestFromState(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		state    state.V4
+		provider string
+		want     ResourceMap
+	}{{
+		name:  "empty",
+		state: state.V4{},
+		want:  ResourceMap{},
+	}, {
+		name: "all permutations, no provider",
+		state: state.V4{
+			Resources: []state.Resource{{
+				Mode:     "data",
+				Type:     "chainguard_roles",
+				Name:     "roles",
+				Provider: "provider[\"registry.terraform.io/chainguard/chainguard\"]",
+			}, {
+				Mode:     "managed",
+				Type:     "chainguard_group",
+				Name:     "group",
+				Provider: "provider[\"registry.terraform.io/chainguard/chainguard\"]",
+				Instances: []state.Instance{{
+					Attributes: map[string]interface{}{
+						"id": "group-id",
+					},
+				}},
+			}, {
+				Module:   "module.my_module",
+				Mode:     "managed",
+				Type:     "chainguard_group",
+				Name:     "group-int-index",
+				Provider: "provider[\"registry.terraform.io/chainguard/chainguard\"]",
+				Instances: []state.Instance{{
+					Attributes: map[string]interface{}{
+						"id": "group-int-index-id",
+					},
+					IndexKey: 0,
+				}},
+			}, {
+				Module:   "module.my_module",
+				Mode:     "managed",
+				Type:     "chainguard_group",
+				Name:     "group-string-index",
+				Provider: "provider[\"registry.terraform.io/chainguard/chainguard\"]",
+				Instances: []state.Instance{{
+					Attributes: map[string]interface{}{
+						"id": "group-string-index-id",
+					},
+					IndexKey: "foo",
+				}},
+			}, {
+				Module:   "module.my_module[\"index\"]",
+				Mode:     "managed",
+				Type:     "chainguard_group",
+				Name:     "group-int-index",
+				Provider: "provider[\"registry.terraform.io/chainguard/chainguard\"]",
+				Instances: []state.Instance{{
+					Attributes: map[string]interface{}{
+						"id": "group-int-index-id",
+					},
+					IndexKey: 0,
+				}},
+			}},
+		},
+		want: ResourceMap{
+			"chainguard_group.group": Tuple{
+				Type: "chainguard_group",
+				Name: "group",
+				ID:   "group-id",
+				Attributes: map[string]interface{}{
+					"id": "group-id",
+				},
+			},
+			"module.my_module.chainguard_group.group-int-index[0]": Tuple{
+				Module:   "module.my_module",
+				Type:     "chainguard_group",
+				Name:     "group-int-index",
+				ID:       "group-int-index-id",
+				IndexKey: 0,
+				Attributes: map[string]interface{}{
+					"id": "group-int-index-id",
+				},
+			},
+			"module.my_module.chainguard_group.group-string-index[\"foo\"]": Tuple{
+				Module:   "module.my_module",
+				Type:     "chainguard_group",
+				Name:     "group-string-index",
+				ID:       "group-string-index-id",
+				IndexKey: "foo",
+				Attributes: map[string]interface{}{
+					"id": "group-string-index-id",
+				},
+			},
+			"module.my_module[\"index\"].chainguard_group.group-int-index[0]": Tuple{
+				Module:   "module.my_module[\"index\"]",
+				Type:     "chainguard_group",
+				Name:     "group-int-index",
+				ID:       "group-int-index-id",
+				IndexKey: 0,
+				Attributes: map[string]interface{}{
+					"id": "group-int-index-id",
+				},
+			},
+		},
+	}} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FromState(tt.state, tt.provider)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Error("FromState() return mismatch (-want, +got):", diff)
 			}
 		})
 	}

--- a/pkg/state/testdata/example.tfstate
+++ b/pkg/state/testdata/example.tfstate
@@ -1,0 +1,169 @@
+{
+  "version": 4,
+  "resources": [
+    {
+      "mode": "data",
+      "type": "chainguard_role",
+      "name": "roles",
+      "provider": "provider[\"registry.terraform.io/chainguard-dev/chainguard\"]",
+      "instances": [
+        {
+          "index_key": "registry.pull",
+          "schema_version": 0,
+          "attributes": {
+            "id": "registry.pull"
+          }
+        },
+        {
+          "index_key": "registry.push",
+          "schema_version": 0,
+          "attributes": {
+            "id": "registry.push"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "chainguard_group",
+      "name": "group",
+      "provider": "provider[\"registry.terraform.io/chainguard-dev/chainguard\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "1350aba7a5c3f0a6e6183b1f8b16fe563bff5150"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "chainguard_group_invite",
+      "name": "invite-code",
+      "provider": "provider[\"registry.terraform.io/chainguard-dev/chainguard\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "1350aba7a5c3f0a6e6183b1f8b16fe563bff5150/4d004baae5b84eb4"
+          },
+          "dependencies": [
+            "chainguard_group.group",
+            "data.chainguard_role.roles"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "chainguard_identity",
+      "name": "assumed-identity",
+      "provider": "provider[\"registry.terraform.io/chainguard-dev/chainguard\"]",
+      "instances": [
+        {
+          "index_key": "api",
+          "schema_version": 0,
+          "attributes": {
+            "id": "1350aba7a5c3f0a6e6183b1f8b16fe563bff5150/10922bb064b4f6ff"
+          },
+          "dependencies": [
+            "chainguard_group.group"
+          ]
+        },
+        {
+          "index_key": "build",
+          "schema_version": 0,
+          "attributes": {
+            "id": "1350aba7a5c3f0a6e6183b1f8b16fe563bff5150/e2f2ce0808ae0d7b"
+          },
+          "dependencies": [
+            "chainguard_group.group"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.api",
+      "mode": "managed",
+      "type": "google_monitoring_alert_policy",
+      "name": "alert",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "id": "projects/prod/alertPolicies/3257823384035534535"
+          },
+          "dependencies": [
+            "chainguard_group.group",
+            "chainguard_identity.assumed-identity",
+            "module.api.module.this.module.this.google_project_iam_member.metrics-writer"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.api.module.gclb[0]",
+      "mode": "managed",
+      "type": "google_compute_backend_service",
+      "name": "public-services",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "index_key": "api",
+          "schema_version": 1,
+          "attributes": {
+            "id": "projects/prod/global/backendServices/api"
+          }
+        }
+      ]
+    },
+    {
+      "module": "module.api.module.this.module.this",
+      "mode": "managed",
+      "type": "google_project_iam_member",
+      "name": "metrics-writer",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "condition": [],
+            "id": "prod/roles/monitoring.metricWriter/serviceAccount:api@prod.iam.gserviceaccount.com",
+            "member": "serviceAccount:api@prod.iam.gserviceaccount.com",
+            "project": "prod",
+            "role": "roles/monitoring.metricWriter"
+          }
+        }
+      ]
+    },
+    {
+      "module": "module.api.module.this.module.this",
+      "mode": "managed",
+      "type": "google_cloud_run_v2_service_iam_member",
+      "name": "public-services-are-unauthenticated",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "index_key": "us-central1",
+          "schema_version": 0,
+          "attributes": {
+            "condition": [],
+            "id": "projects/prod/locations/us-central1/services/api/roles/run.invoker/allUsers",
+            "location": "us-central1",
+            "member": "allUsers",
+            "name": "projects/prod/locations/us-central1/services/api",
+            "project": "prod",
+            "role": "roles/run.invoker"
+          },
+          "dependencies": [
+            "chainguard_group.group",
+            "chainguard_identity.assumed-identity"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/state/v4.go
+++ b/pkg/state/v4.go
@@ -11,6 +11,7 @@ type V4 struct {
 }
 
 type Resource struct {
+	Module    string
 	Mode      string
 	Type      string
 	Name      string

--- a/pkg/state/v4_test.go
+++ b/pkg/state/v4_test.go
@@ -1,0 +1,161 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestParseStateFile(t *testing.T) {
+	for _, c := range []struct {
+		name     string
+		filename string
+		want     V4
+	}{{
+		name:     "example.tfstate",
+		filename: "testdata/example.tfstate",
+		want: V4{
+			Version: 4,
+			Resources: []Resource{{
+				Mode:     "data",
+				Type:     "chainguard_role",
+				Name:     "roles",
+				Provider: "provider[\"registry.terraform.io/chainguard-dev/chainguard\"]",
+				Instances: []Instance{{
+					IndexKey: "registry.pull",
+					Attributes: map[string]interface{}{
+						"id": "registry.pull",
+					},
+				}, {
+					IndexKey: "registry.push",
+					Attributes: map[string]interface{}{
+						"id": "registry.push",
+					},
+				}},
+			}, {
+				Mode:     "managed",
+				Type:     "chainguard_group",
+				Name:     "group",
+				Provider: "provider[\"registry.terraform.io/chainguard-dev/chainguard\"]",
+				Instances: []Instance{{
+					Attributes: map[string]interface{}{
+						"id": "1350aba7a5c3f0a6e6183b1f8b16fe563bff5150",
+					},
+				}},
+			}, {
+				Mode:     "managed",
+				Type:     "chainguard_group_invite",
+				Name:     "invite-code",
+				Provider: "provider[\"registry.terraform.io/chainguard-dev/chainguard\"]",
+				Instances: []Instance{{
+					Attributes: map[string]interface{}{
+						"id": "1350aba7a5c3f0a6e6183b1f8b16fe563bff5150/4d004baae5b84eb4",
+					},
+					Dependencies: []string{
+						"chainguard_group.group",
+						"data.chainguard_role.roles",
+					},
+				}},
+			}, {
+				Mode:     "managed",
+				Type:     "chainguard_identity",
+				Name:     "assumed-identity",
+				Provider: "provider[\"registry.terraform.io/chainguard-dev/chainguard\"]",
+				Instances: []Instance{{
+					IndexKey: "api",
+					Attributes: map[string]interface{}{
+						"id": "1350aba7a5c3f0a6e6183b1f8b16fe563bff5150/10922bb064b4f6ff",
+					},
+					Dependencies: []string{
+						"chainguard_group.group",
+					},
+				}, {
+					IndexKey: "build",
+					Attributes: map[string]interface{}{
+						"id": "1350aba7a5c3f0a6e6183b1f8b16fe563bff5150/e2f2ce0808ae0d7b",
+					},
+					Dependencies: []string{
+						"chainguard_group.group",
+					},
+				}},
+			}, {
+				Mode:     "managed",
+				Module:   "module.api",
+				Type:     "google_monitoring_alert_policy",
+				Name:     "alert",
+				Provider: "provider[\"registry.terraform.io/hashicorp/google\"]",
+				Instances: []Instance{{
+					// json.Unmarshal defaults to float64 for json numbers
+					IndexKey: float64(0),
+					Attributes: map[string]interface{}{
+						"id": "projects/prod/alertPolicies/3257823384035534535",
+					},
+					Dependencies: []string{
+						"chainguard_group.group",
+						"chainguard_identity.assumed-identity",
+						"module.api.module.this.module.this.google_project_iam_member.metrics-writer",
+					},
+				}},
+			}, {
+				Mode:     "managed",
+				Module:   "module.api.module.gclb[0]",
+				Type:     "google_compute_backend_service",
+				Name:     "public-services",
+				Provider: "provider[\"registry.terraform.io/hashicorp/google\"]",
+				Instances: []Instance{{
+					IndexKey: "api",
+					Attributes: map[string]interface{}{
+						"id": "projects/prod/global/backendServices/api",
+					},
+				}},
+			}, {
+				Mode:     "managed",
+				Module:   "module.api.module.this.module.this",
+				Type:     "google_project_iam_member",
+				Name:     "metrics-writer",
+				Provider: "provider[\"registry.terraform.io/hashicorp/google\"]",
+				Instances: []Instance{{
+					Attributes: map[string]interface{}{
+						"condition": []any{},
+						"id":        "prod/roles/monitoring.metricWriter/serviceAccount:api@prod.iam.gserviceaccount.com",
+						"member":    "serviceAccount:api@prod.iam.gserviceaccount.com",
+						"project":   "prod",
+						"role":      "roles/monitoring.metricWriter",
+					},
+				}},
+			}, {
+				Mode:     "managed",
+				Module:   "module.api.module.this.module.this",
+				Type:     "google_cloud_run_v2_service_iam_member",
+				Name:     "public-services-are-unauthenticated",
+				Provider: "provider[\"registry.terraform.io/hashicorp/google\"]",
+				Instances: []Instance{{
+					IndexKey: "us-central1",
+					Attributes: map[string]interface{}{
+						"condition": []any{},
+						"id":        "projects/prod/locations/us-central1/services/api/roles/run.invoker/allUsers",
+						"location":  "us-central1",
+						"member":    "allUsers",
+						"name":      "projects/prod/locations/us-central1/services/api",
+						"project":   "prod",
+						"role":      "roles/run.invoker",
+					},
+					Dependencies: []string{
+						"chainguard_group.group",
+						"chainguard_identity.assumed-identity",
+					},
+				}},
+			}},
+		},
+	}} {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := ParseStateFile(c.filename)
+			if err != nil {
+				t.Fatalf("failed to parse statefile \"testdata/example.tfstate\": %v", err)
+			}
+			if diff := cmp.Diff(c.want, got); diff != "" {
+				t.Errorf("ParseStateFile() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Fix the handling of numerical index keys; `json.Unmarshal` casts json numbers as `float64` by default, so handle this case properly. 
- Add `Tuple.ImportableID()` to generate the expected ID for import, based on resource type. Most resources will return the `ID` field directly, but some require special formatting (e.g. gcp IAM members and bindings).
- Remove `-out` flag, print to `os.Stdout` always.
- Add unit tests.